### PR TITLE
Send 500 and close connection if file operations fail

### DIFF
--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -135,8 +135,13 @@ handle('GET', [<<"decoded-list">>], Req) ->
 handle('GET', [<<"sendfile">>], _Req) ->
     %% Returning {file, "/path/to/file"} instead of the body results
     %% in Elli using sendfile.
-    %% All required headers should be added by the handler.
     F    = "README.md",
+    {ok, [], {file, F}};
+
+handle('GET', [<<"send_no_file">>], _Req) ->
+    %% Returning {file, "/path/to/file"} instead of the body results
+    %% in Elli using sendfile.
+    F    = "README",
     {ok, [], {file, F}};
 
 handle('GET', [<<"sendfile">>, <<"range">>], Req) ->


### PR DESCRIPTION
The idea is that Elli was asked to send a file that doesn't exist or can't be accessed we send 500.

Also send bad request body (Content-Length was set but no body)
