### PR TITLE
Replace uri decoder from inets

### DIFF
--- a/src/elli.app.src
+++ b/src/elli.app.src
@@ -19,8 +19,7 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib,
-                  inets
+                  stdlib
                  ]},
   {env, []},
 

--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -266,9 +266,25 @@ is_request(_)      -> false.
 
 
 -ifdef(binary_http_uri).
-uri_decode(EncodedValue) ->
-    http_uri:decode(EncodedValue).
+uri_decode(<<$+, Rest/binary>>) ->
+    <<$ , (uri_decode(Rest))/binary>>;
+uri_decode(<<$%, Hex:2/bytes, Rest/binary>>) ->
+    <<(binary_to_integer(Hex, 16)), (uri_decode(Rest))/binary>>;
+uri_decode(<<C, Rest/binary>>) ->
+    <<C, (uri_decode(Rest))/binary>>;
+uri_decode(<<>>) ->
+    <<>>.
 -else.
-uri_decode(EncodedValue) ->
-    list_to_binary(http_uri:decode(binary_to_list(EncodedValue))).
+uri_decode(<<$+, Rest/binary>>) ->
+    <<$ , (uri_decode(Rest))/binary>>;
+uri_decode(<<$%, HexA, HexB, Rest/binary>>) ->
+    <<(hex_to_int(HexA)*16+hex_to_int(HexB)), (uri_decode(Rest))/binary>>;
+uri_decode(<<C, Rest/binary>>) ->
+    <<C, (uri_decode(Rest))/binary>>;
+uri_decode(<<>>) ->
+    <<>>.
+
+hex_to_int(X) when X >= $0, X =< $9 -> X-$0;
+hex_to_int(X) when X >= $a, X =< $f -> X-$a+10;
+hex_to_int(X) when X >= $A, X =< $F -> X-$A+10.
 -endif.


### PR DESCRIPTION
Replaces all calls to 'http_uri:decode/1' from the inets application
with a custom function local to elli. This allows the removal of inets
as a dependency.