### PR TITLE
logging and stacktrace OTP-21 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,8 +23,9 @@
   {coveralls, "1.4.0"},
   {rebar3_lint, "0.1.9"}
 ]}.
-
-{provider_hooks, [{pre, [{eunit, lint}]}]}.
+{plugins, [{rebar_erl_vsn, "0.1.7"}]}.
+{provider_hooks, [{pre, [{compile, erl_vsn},
+                         {eunit, lint}]}]}.
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/src/elli.erl
+++ b/src/elli.erl
@@ -218,14 +218,14 @@ handle_cast(_Msg, State) ->
       Result :: {stop, emfile, State0}
               | {noreply, State1 :: state()}.
 handle_info({'EXIT', _Pid, {error, emfile}}, State) ->
-    ?ERROR("No more file descriptors, shutting down~n"),
+    ?LOG_ERROR("No more file descriptors, shutting down~n"),
     {stop, emfile, State};
 
 handle_info({'EXIT', Pid, normal}, State) ->
     {noreply, remove_acceptor(State, Pid)};
 
 handle_info({'EXIT', Pid, Reason}, State) ->
-    ?ERROR("Elli request (pid ~p) unexpectedly crashed:~n~p~n", [Pid, Reason]),
+    ?LOG_ERROR("Elli request (pid ~p) unexpectedly crashed:~n~p~n", [Pid, Reason]),
     {noreply, remove_acceptor(State, Pid)}.
 
 

--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -226,7 +226,7 @@ chunk_loop(Ref, N) ->
 
     case elli_request:send_chunk(Ref, [<<"chunk">>, ?I2L(N)]) of
         ok              -> ok;
-        {error, Reason} -> ?ERROR("error in sending chunk: ~p~n", [Reason])
+        {error, Reason} -> ?LOG_ERROR("error in sending chunk: ~p~n", [Reason])
     end,
 
     chunk_loop(Ref, N-1).

--- a/src/elli_util.hrl
+++ b/src/elli_util.hrl
@@ -1,8 +1,24 @@
 -define(I2L(I), integer_to_list(I)).
--define(B2I(I), list_to_integer(binary_to_list(I))).
 
--define(ERROR(Str), error_logger:error_msg(Str)).
--define(ERROR(Format,Data), error_logger:error_msg(Format, Data)).
+-ifdef('16.0').
+-define(B2I(I), binary_to_integer(I)).
+-else.
+-define(B2I(I), list_to_integer(binary_to_list(I))).
+-endif.
+
+-ifdef('21.0').
+-include_lib("kernel/include/logger.hrl").
+-else.
+-define(LOG_ERROR(Str), error_logger:error_msg(Str)).
+-define(LOG_ERROR(Format,Data), error_logger:error_msg(Format, Data)).
+-define(LOG_INFO(Format,Data), error_logger:info_msg(Format, Data)).
+-endif.
+
+-ifdef('21.0').
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-else.
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
+-endif.
 
 %% Bloody useful
 -define(IF(Test,True,False), case Test of true -> True; false -> False end).

--- a/test/elli_tests.erl
+++ b/test/elli_tests.erl
@@ -8,6 +8,13 @@
 -define(VTB(T1, T2, LB, UB),
         time_diff_to_micro_seconds(T1, T2) >= LB andalso
         time_diff_to_micro_seconds(T1, T2) =< UB).
+-ifdef('21.0').
+-include_lib("kernel/include/logger.hrl").
+-else.
+-define(LOG_ERROR(Str), error_logger:error_msg(Str)).
+-define(LOG_ERROR(Format,Data), error_logger:error_msg(Format, Data)).
+-define(LOG_INFO(Format,Data), error_logger:info_msg(Format, Data)).
+-endif.
 
 time_diff_to_micro_seconds(T1, T2) ->
     erlang:convert_time_unit(
@@ -541,8 +548,8 @@ get_pipeline() ->
         true ->
             ok;
         false ->
-            error_logger:info_msg("Expected: ~p~nResult: ~p~n",
-                                  [binary:copy(ExpectedResponse, 2), Res])
+            ?LOG_INFO("Expected: ~p~nResult: ~p~n",
+                      [binary:copy(ExpectedResponse, 2), Res])
     end,
 
     ?assertEqual(binary:copy(ExpectedResponse, 2),
@@ -606,7 +613,7 @@ send(Socket, B, ChunkSize) ->
                        <<P:ChunkSize/binary, R/binary>> -> {P, R};
                        P -> {P, <<>>}
                    end,
-    %%error_logger:info_msg("~p~n", [Part]),
+    %%?LOG_INFO("~p~n", [Part]),
     gen_tcp:send(Socket, Part),
     timer:sleep(1),
     send(Socket, Rest, ChunkSize).


### PR DESCRIPTION
Not sure if we need the `ifdef` around 16 in the header for `binary_to_integer`, can probably drop support for anything before 17?

But it doesn't really hurt, so we can worry about that later I suppose.