### PR TITLE
add post edoc hook to build html from markdown

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
   {rebar3_lint, "0.1.9"}
 ]}.
 {plugins, [{rebar_erl_vsn, "0.1.7"}]}.
-{provider_hooks, [{pre, [{compile, erl_vsn},
+{provider_hooks, [{pre, [{compile, {default, erl_vsn}},
                          {eunit, lint}]}]}.
 
 {cover_enabled, true}.
@@ -35,3 +35,5 @@
 ]}.
 {coveralls_coverdata, "_build/test/cover/eunit.coverdata"}.
 {coveralls_service_name, "travis-ci"}.
+
+{post_hooks, [{edoc, "doc/build.sh"}]}.


### PR DESCRIPTION
Forgot this. This hook runs the script to generate html from markdown after `edoc` runs, which is a dep of `rebar3 hex docs` to publish the docs.