### PR TITLE
Allow for warningless OTP 21 compilation and dialyzer'ing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_first_files, ["src/elli_handler.erl"]}.
-{erl_opts, [debug_info, {i, "include"}, {platform_define, "^2", binary_http_uri}]}.
+{erl_opts, [debug_info, {i, "include"}, {platform_define, "^2", binary_http_uri}, {platform_define, "^2[1-9]", post20}]}.
 {minimum_otp_vsn, "18.0"}.
 {deps, []}.
 {xref_checks, [undefined_function_calls,locals_not_used]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {erl_first_files, ["src/elli_handler.erl"]}.
 {erl_opts, [debug_info, {i, "include"}, {platform_define, "^2", binary_http_uri}]}.
+{minimum_otp_vsn, "18.0"}.
 {deps, []}.
 {xref_checks, [undefined_function_calls,locals_not_used]}.
 {profiles, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_first_files, ["src/elli_handler.erl"]}.
-{erl_opts, [debug_info, {i, "include"}, {platform_define, "^2", binary_http_uri}, {platform_define, "^2[1-9]", post20}]}.
+{erl_opts, [debug_info, {i, "include"}, {platform_define, "^2", binary_http_uri}, {platform_define, "^2[1-9]", post20}, {parse_transform, stacktrace_transform}]}.
 {minimum_otp_vsn, "18.0"}.
-{deps, []}.
+{deps, [{stacktrace_compat, "1.0.0"}]}.
 {xref_checks, [undefined_function_calls,locals_not_used]}.
 {profiles, [
   {docs, [

--- a/rebar.config
+++ b/rebar.config
@@ -28,6 +28,7 @@
 {plugins, [{rebar_erl_vsn, "0.1.7"}]}.
 {provider_hooks, [{pre, [{compile, {default, erl_vsn}},
                          {eunit, lint}]}]}.
+{dialyzer, [{plt_extra_apps, [ssl]}]}.
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,6 @@
-[].
+{"1.1.0",
+[{<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"stacktrace_compat">>, <<"78E13E0747FABC71DC725A49A4CBDDE54CEC1E9ED13BD80C1D35AC37182E1FA0">>}]}
+].

--- a/src/elli_sendfile.erl
+++ b/src/elli_sendfile.erl
@@ -13,7 +13,7 @@
 %% Originally from https://github.com/ninenines/ranch/pull/41/files
 %%
 %% @end
--spec sendfile(file:fd(), elli_tcp:socket(),
+-spec sendfile(file:fd(), inet:socket() | ssl:sslsocket(),
         non_neg_integer(), non_neg_integer(), sendfile_opts())
     -> {ok, non_neg_integer()} | {error, atom()}.
 sendfile(RawFile, Socket, Offset, Bytes, Opts) ->
@@ -45,7 +45,7 @@ chunk_size(Opts) ->
             16#1FFF
     end.
 
--spec sendfile_loop(elli_tcp:socket(), file:fd(), non_neg_integer(),
+-spec sendfile_loop(inet:socket() | ssl:sslsocket(), file:fd(), non_neg_integer(),
         non_neg_integer(), pos_integer())
     -> {ok, non_neg_integer()} | {error, term()}.
 sendfile_loop(_Socket, _RawFile, Sent, Sent, _ChunkSize)


### PR DESCRIPTION
We also make for an explicit minimum OTP 18 version (in rebar.config), as per .travis.yml's example.