### PR TITLE
remove rebar_erl_vsn plugin and replace with OTP_RELEASE

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,9 +25,8 @@
   {coveralls, "1.4.0"},
   {rebar3_lint, "0.1.9"}
 ]}.
-{plugins, [{rebar_erl_vsn, "0.1.7"}]}.
-{provider_hooks, [{pre, [{compile, {default, erl_vsn}},
-                         {eunit, lint}]}]}.
+
+{provider_hooks, [{pre, [{eunit, lint}]}]}.
 {dialyzer, [{plt_extra_apps, [ssl]}]}.
 
 {cover_enabled, true}.

--- a/src/elli_util.hrl
+++ b/src/elli_util.hrl
@@ -1,5 +1,5 @@
 
--ifdef('21.0').
+-ifdef(OTP_RELEASE).
 -include_lib("kernel/include/logger.hrl").
 -else.
 -define(LOG_ERROR(Str), error_logger:error_msg(Str)).
@@ -7,7 +7,7 @@
 -define(LOG_INFO(Format,Data), error_logger:info_msg(Format, Data)).
 -endif.
 
--ifdef('21.0').
+-ifdef(OTP_RELEASE).
 -define(WITH_STACKTRACE(T, R, S), T:R:S ->).
 -else.
 -define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).

--- a/test/elli_tests.erl
+++ b/test/elli_tests.erl
@@ -7,7 +7,7 @@
 -define(VTB(T1, T2, LB, UB),
         time_diff_to_micro_seconds(T1, T2) >= LB andalso
         time_diff_to_micro_seconds(T1, T2) =< UB).
--ifdef('21.0').
+-ifdef(OTP_RELEASE).
 -include_lib("kernel/include/logger.hrl").
 -else.
 -define(LOG_ERROR(Str), error_logger:error_msg(Str)).


### PR DESCRIPTION
This plugin will always get out of date and issue a warning. Since it doesn't appear to even be needed for what we were using it for I've removed it and replaced its use with the `OTP_RELEASE` macro that was added to otp.