### PR TITLE
do not use x-forwarded-for for peer

### DIFF
--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -67,18 +67,12 @@ host(#req{host = Host})          -> Host.
 port(#req{port = Port})          -> Port.
 
 peer(#req{socket = Socket} = Req) ->
-    case get_header(<<"X-Forwarded-For">>, Req, undefined) of
-        undefined ->
-            case elli_tcp:peername(Socket) of
-                {ok, {Address, _}} ->
-                    list_to_binary(inet_parse:ntoa(Address));
-                {error, _} ->
-                    undefined
-            end;
-        Ip ->
-            Ip
+    case elli_tcp:peername(Socket) of
+        {ok, {Address, _}} ->
+            list_to_binary(inet_parse:ntoa(Address));
+        {error, _} ->
+            undefined
     end.
-
 
 %% @equiv proplists:get_value(Key, Headers)
 get_header(Key, #req{headers = Headers}) ->


### PR DESCRIPTION
This was brought to our attention in this issue https://github.com/elli-lib/elli/issues/68

I finally went and dug through the git logs to try finding why Elli ever used x-forwarded-for for the peer and there does not appear to be an explanation. So I think simply removing it is the best course of action.