### PR TITLE
Fix compile-time warnings on missing record info. from aleppo

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 
 {project_plugins, [
   {coveralls, "1.4.0"},
-  {rebar3_lint, "0.1.9"}
+  {rebar3_lint, "v0.1.10"}
 ]}.
 
 {provider_hooks, [{pre, [{eunit, lint}]}]}.

--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -66,7 +66,7 @@ host(#req{host = Host})          -> Host.
 %% @doc Return the `port'.
 port(#req{port = Port})          -> Port.
 
-peer(#req{socket = Socket} = Req) ->
+peer(#req{socket = Socket} = _Req) ->
     case elli_tcp:peername(Socket) of
         {ok, {Address, _}} ->
             list_to_binary(inet_parse:ntoa(Address));


### PR DESCRIPTION
Before this change:
rebar3_lint > elvis > katana_code > aleppo

After this change:
rebar3_lint > elvis > katana_code (since aleppo isn't called, warning is gone)