### PR TITLE
Handle arguments with no value in (post|get)_arg_decoded

### DIFF
--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -97,6 +97,7 @@ get_arg_decoded(Key, #req{} = Req) ->
 get_arg_decoded(Key, #req{args = Args}, Default) ->
     case proplists:get_value(Key, Args) of
         undefined    -> Default;
+        true         -> true;
         EncodedValue ->
             uri_decode(EncodedValue)
     end.
@@ -127,6 +128,7 @@ post_arg_decoded(Key, #req{} = Req) ->
 post_arg_decoded(Key, #req{} = Req, Default) ->
     case proplists:get_value(Key, body_qs(Req)) of
         undefined    -> Default;
+        true         -> true;
         EncodedValue ->
             uri_decode(EncodedValue)
     end.


### PR DESCRIPTION
To follow the convention in (get|post)_args_decoded, return true
directly and do not attempt to uridecode it, as it will fail.