### PR TITLE
Fix unexpected crash during SSL tests

### DIFF
--- a/test/elli_ssl_tests.erl
+++ b/test/elli_ssl_tests.erl
@@ -101,10 +101,10 @@ setup() ->
     [P].
 
 teardown(Pids) ->
+    [elli:stop(P) || P <- Pids],
     application:stop(ssl),
     application:stop(public_key),
-    application:stop(crypto),
-    [elli:stop(P) || P <- Pids].
+    application:stop(crypto).
 
 init_stats() ->
     ets:new(elli_stat_table, [set, named_table, public]).


### PR DESCRIPTION
Crash (didn't affect tests, but gave off the impression something was wrong) was:
```erlang
=ERROR REPORT==== 29-Oct-2020::11:08:45 ===
Elli request (pid #Port<0.86655>) unexpectedly crashed:
shutdown

=ERROR REPORT==== 29-Oct-2020::11:08:45 ===
Elli request (pid <0.396.0>) unexpectedly crashed:
{shutdown,{gen_statem,call,[<0.437.0>,{recv,0,60000},infinity]}}
```