### PR TITLE
Handling unexpected integer status codes

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -901,6 +901,7 @@ status(506) -> <<"506 Variant Also Negotiates">>;
 status(507) -> <<"507 Insufficient Storage">>;
 status(510) -> <<"510 Not Extended">>;
 status(511) -> <<"511 Network Authentication Required">>;
+status(I) when is_integer(I), I >= 100, I < 1000 -> list_to_binary(io_lib:format("~B Status", [I]));
 status(B) when is_binary(B) -> B.
 
 


### PR DESCRIPTION
This PR acts as a fall-through for receiving an uncommon or non-standard HTTP status code in the Elli handler and converting it to a response code string to prevent the handler from crashing. Validates the response code received as being an integer within the range established by the [response_code type](https://github.com/elli-lib/elli/blob/3fa6faa816a2b92cd64149744d8f7dd43bfe1565/src/elli.erl#L43).

Addresses https://github.com/elli-lib/elli/issues/95.