### PR TITLE
Exposing additional functions for external use

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -682,12 +682,7 @@ connection_token(#req{version = {0, 9}}) ->
       Headers   :: elli:headers(),
       KeepaliveOpt :: close | keep_alive.
 close_or_keepalive(Req, UserHeaders) ->
-    case get_header(?CONNECTION_HEADER, UserHeaders) of
-        undefined ->
-            case connection_token(Req) of
-                <<"Keep-Alive">> -> keep_alive;
-                <<"close">>      -> close
-            end;
+    case get_header(?CONNECTION_HEADER, UserHeaders, connection_token(Req)) of
         <<"close">>      -> close;
         <<"Keep-Alive">> -> keep_alive
     end.


### PR DESCRIPTION
Closes https://github.com/elli-lib/elli/issues/97 by making some existing functions accessible to external library users, particularly libraries operating with a handler in `handover` mode where the responses will be manually constructed by the implementing application or library.

`elli_http:send_file/5` - mirrors the already public `elli_http:send_response/4` for sending file content
`elli_http:close_or_keepalive/4` - manually handle responses with the correct keepalive setting based on the req