### PR TITLE
Fix spec for elli:stop/1

### DIFF
--- a/src/elli.erl
+++ b/src/elli.erl
@@ -107,7 +107,7 @@ set_callback(S, Callback, CallbackArgs) ->
     gen_server:call(S, {set_callback, Callback, CallbackArgs}).
 
 %% @doc Stop `Server'.
--spec stop(Server :: atom()) -> {stop, normal, ok, state()}.
+-spec stop(Server :: atom()) -> ok.
 stop(S) ->
     gen_server:call(S, stop).
 


### PR DESCRIPTION
Closes #111.

Depends on the CI file updates from #114, so shall be rebased and updated (if required) after that one.