### PR TITLE
Increase confidence in Dialyzer and Xref results

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
             {i, "include"}]}.
 {minimum_otp_vsn, "24"}.
 {deps, []}.
-{xref_checks, [undefined_function_calls,locals_not_used]}.
+{xref_checks, [deprecated_function_calls,undefined_function_calls,locals_not_used]}.
 {profiles, [
   {docs, [
     {deps,      [{edown, "0.9.1"}]},
@@ -28,7 +28,7 @@
 ]}.
 
 {provider_hooks, [{pre, [{eunit, lint}]}]}.
-{dialyzer, [{plt_extra_apps, [ssl]}]}.
+{dialyzer, [{plt_extra_apps, [ssl]}, {warnings, [unknown]}]}.
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -297,7 +297,7 @@ chunk_loop(Ref, N) ->
 %% `file_error' is sent when the user wants to return a file as a
 %% response, but for some reason it cannot be opened.
 -spec handle_event(Event, Args, Config) -> ok when
-      Event  :: elli:event(),
+      Event  :: elli_handler:event(),
       Args   :: elli_handler:callback_args(),
       Config :: [tuple()].
 handle_event(elli_startup, [], _) -> ok;

--- a/src/elli_middleware.erl
+++ b/src/elli_middleware.erl
@@ -86,7 +86,7 @@ handle_event(Event, Args, Config) ->
 
 -spec do_init(Req, Callbacks) -> {ok, standard | handover} when
       Req       :: elli:req(),
-      Callbacks :: elli_handler:callbacks().
+      Callbacks :: [elli_handler:callback()].
 do_init(_, []) ->
     {ok, standard};
 do_init(Req, [{Mod, Args}|Mods]) ->


### PR DESCRIPTION
We make `rebar.config` a bit more restrictive, and then act on that.